### PR TITLE
fix: don't import jwt-private.h

### DIFF
--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -2,9 +2,9 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
+#include <jansson.h>
 
 #include "jwt/jwt.h"
-#include "jwt/jwt-private.h"
 #include "jwk.h"
 
 #define NGX_HTTP_AUTH_JWT_CLAIM_VAR_PREFIX "jwt_claim_"


### PR DESCRIPTION
It's private... and actually not needed here, except `#import <jansson.h>` that should be included directly.