### PR TITLE
Support for nested claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The module can be used for
 [OpenID Connect](http://openid.net/specs/openid-connect-core-1_0.html)
 authentication.
 
-> This modules is heavenly inspired by the nginx original
+> This module is heavily inspired by the nginx original
 > [http_auth_jwt_module](http://nginx.org/en/docs/http/ngx_http_auth_jwt_module.html).
 
 Dependency
@@ -52,7 +52,7 @@ $ : "app.conf: Create nginx configuration"
 $ docker run -p 80:80 -v $PWD/app.conf:/etc/nginx/http.d/default.conf nginx-auth-jwt
 ```
 
-> Github package: ghcr.io/kjdev/nginx-auth-jwt
+> GitHub package: ghcr.io/kjdev/nginx-auth-jwt
 
 Supported Algorithms
 --------------------
@@ -95,6 +95,7 @@ location / {
 - [auth\_jwt\_require](#auth_jwt_require)
 - [auth\_jwt\_require\_claim](#auth_jwt_require_claim)
 - [auth\_jwt\_require\_header](#auth_jwt_require_header)
+- [auth\_jwt\_allow\_nested](#auth_jwt_allow_nested)
 
 <a name="auth_jwt"></a>
 ```
@@ -111,7 +112,7 @@ The optional `token` parameter specifies a variable that contains
 JSON Web Token.
 By default, JWT is passed in the `Authorization` header as a
 [Bearer Token](https://datatracker.ietf.org/doc/html/rfc6750).
-JWT may be also passed as a cookie or a part of a query string:
+JWT may also be passed as a cookie or part of a query string:
 
 > ```
 > auth_jwt "closed site" token=$cookie_auth_token;
@@ -433,6 +434,39 @@ Specifies a requirement for header in jwt token.
 
 All possibilities of this directive are the same as for
 [auth\_jwt\_require\_claim](#auth_jwt_require_claim) above.
+
+<a name="auth_jwt_allow_nested"></a>
+```
+Syntax: auth_jwt_allow_nested [delimiter=string] [quote=string];
+Default: -
+Context: http
+```
+Allow access to nested claim/headers in jwt token.
+
+The optional `delimiter` parameter sets the nesting delimiter
+(default value is `.`).
+
+The optional `quote` parameter sets the quote character for the key
+(default value is `"`).
+
+> Examples:
+> ```
+> auth_jwt_allow_nested;
+> server {
+>   auth_jwt_require_claim grants.access eq allow;
+>   auth_jwt_require_claim '"grants.key"' eq dot;
+> }
+> ```
+>
+> JWT payload:
+> ```
+> {
+>   "grants": {
+>     "access": "allow"
+>   },
+>   "grants.key": "dot"
+> }
+> ```
 
 ### Embedded Variables
 

--- a/config
+++ b/config
@@ -7,6 +7,7 @@ ngx_module_srcs="$ngx_addon_dir/src/jwt/base64.c \
                  $ngx_addon_dir/src/jwt/jwt-openssl.c \
                  $ngx_addon_dir/src/jwt/jwt.c \
                  $ngx_addon_dir/src/jwk.c \
+                 $ngx_addon_dir/src/jwt_get_claims.c \
                  $ngx_addon_dir/src/jwt_requirement_operators.c \
                  $ngx_addon_dir/src/ngx_http_auth_jwt_module.c"
 ngx_module_deps=

--- a/src/jwt/base64.c
+++ b/src/jwt/base64.c
@@ -82,7 +82,7 @@
 /* Base64 encoder/decoder. Originally Apache file ap_base64.c
  */
 
-/* Originally of https://github.com/benmcollins/libjwt at v1.15.3 */
+/* Originally of https://github.com/benmcollins/libjwt at v1.17.0 */
 
 #include <string.h>
 
@@ -136,7 +136,7 @@ int jwt_Base64decode(char *bufplain, const char *bufcoded)
     nprbytes -= 4;
     }
 
-    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
+    /* Note: (nprbytes == 1) would be an error, so just ignore that case */
     if (nprbytes > 1) {
     *(bufout++) =
         (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);

--- a/src/jwt/base64.h
+++ b/src/jwt/base64.h
@@ -79,7 +79,7 @@
  *
  */
 
-/* Originally of https://github.com/benmcollins/libjwt at v1.15.3 */
+/* Originally of https://github.com/benmcollins/libjwt at v1.17.0 */
 
 
 #ifndef _JWT_BASE64_H_

--- a/src/jwt/jwt-private.h
+++ b/src/jwt/jwt-private.h
@@ -1,11 +1,12 @@
-/* Copyright (C) 2015-2022 Ben Collins <bcollins@maclara-llc.com>
+/* Copyright (C) 2015-2024 Ben Collins <bcollins@maclara-llc.com>
    This file is part of the JWT C Library
 
+   SPDX-License-Identifier:  MPL-2.0
    This Source Code Form is subject to the terms of the Mozilla Public
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Originally of https://github.com/benmcollins/libjwt at v1.15.3 */
+/* Originally of https://github.com/benmcollins/libjwt at v1.17.0 */
 
 #ifndef JWT_PRIVATE_H
 #define JWT_PRIVATE_H
@@ -49,6 +50,9 @@ int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 		     const char *str, unsigned int str_len);
 
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig_b64);
+
+/* A time-safe strcmp function */
+int jwt_strcmp(const char *str1, const char *str2);
 
 /* Extends */
 int jwt_parse(jwt_t **jwt, const char *token, unsigned int *len);

--- a/src/jwt/jwt.h
+++ b/src/jwt/jwt.h
@@ -1,11 +1,12 @@
-/* Copyright (C) 2015-2022 Ben Collins <bcollins@maclara-llc.com>
+/* Copyright (C) 2015-2023 Ben Collins <bcollins@maclara-llc.com>
    This file is part of the JWT C Library
 
+   SPDX-License-Identifier:  MPL-2.0
    This Source Code Form is subject to the terms of the Mozilla Public
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* Originally of https://github.com/benmcollins/libjwt at v1.15.3 */
+/* Originally of https://github.com/benmcollins/libjwt at v1.17.0 */
 
 /**
  * @file jwt.h
@@ -65,6 +66,11 @@ typedef enum jwt_alg {
 	JWT_ALG_ES256,
 	JWT_ALG_ES384,
 	JWT_ALG_ES512,
+#ifndef HAVE_OPENSSL
+	JWT_ALG_PS256,
+	JWT_ALG_PS384,
+	JWT_ALG_PS512,
+#endif
 	JWT_ALG_TERM
 } jwt_alg_t;
 
@@ -713,7 +719,7 @@ JWT_EXPORT void jwt_get_alloc(jwt_malloc_t *pmalloc, jwt_realloc_t *prealloc, jw
  /** @} */
 
 /**
- * @defgroup jwt_vaildate JWT validation functions
+ * @defgroup jwt_validate JWT validation functions
  * These functions allow you to define requirements for JWT validation.
  *
  * The most basic validation is that the JWT uses the expected algorithm.
@@ -979,6 +985,21 @@ JWT_EXPORT int jwt_valid_set_exp_leeway(jwt_valid_t *jwt_valid, const time_t exp
  *     header or body.
  */
 JWT_EXPORT int jwt_valid_set_headers(jwt_valid_t *jwt_valid, int hdr);
+
+/**
+ * Parses exceptions and returns a comma delimited and human-readable string.
+ *
+ * The returned string must be freed by the caller. If you changed the allocation
+ * method using jwt_set_alloc, then you must use jwt_free_str() to free the memory.
+ *
+ * Note: This string is currently en-US ASCII only. Language support will come in the
+ * future.
+ *
+ * @param exceptions Integer containing the exception flags.
+ * @return A null terminated string on success, NULL on error with errno
+ *     set appropriately.
+ */
+JWT_EXPORT char *jwt_exception_str(unsigned int exceptions);
 
 /** @} */
 

--- a/src/jwt_get_claims.c
+++ b/src/jwt_get_claims.c
@@ -1,0 +1,334 @@
+#include <errno.h>
+#include <jansson.h>
+#include <string.h>
+#include "jwt_get_claims.h"
+#include "jwt/jwt-private.h"
+
+static json_t *
+get_js_json(const json_t *js, const char *key,
+            const char *delim, const char *quote)
+{
+  json_t *js_val = NULL;
+
+  if (!js) {
+    return NULL;
+  }
+
+  js_val = (json_t *) js;
+
+  if (key && strlen(key) && js_val != NULL) {
+    json_t *js_obj = NULL;
+
+    if (delim) {
+      char *p = NULL, *s = NULL, *var = NULL;
+      size_t delim_len = strlen(delim), quote_len = 0;
+
+      var = strdup(key);
+      if (!var) {
+        return NULL;
+      }
+
+      s = var;
+
+      if (quote) {
+        quote_len = strlen(quote);
+      }
+
+      do {
+        if (s && quote && strncmp(s, quote, quote_len) == 0) {
+          s += quote_len;
+          p = strsep(&s, quote);
+          if (p && strlen(p)) {
+            if (s) {
+              s += quote_len - 1;
+            }
+            js_obj = json_object_get(js_val, p);
+            if (js_obj == NULL) {
+              js_val = NULL;
+              break;
+            }
+            js_val = js_obj;
+          }
+        }
+
+        p = strsep(&s, delim);
+        if (p && strlen(p)) {
+          if (s) {
+            s += delim_len - 1;
+          }
+          js_obj = json_object_get(js_val, p);
+          if (js_obj == NULL) {
+            js_val = NULL;
+            break;
+          }
+          js_val = js_obj;
+        }
+      } while (p);
+
+      free(var);
+    }
+    else {
+      js_obj = json_object_get(js_val, key);
+      if (js_obj == NULL) {
+        js_val = NULL;
+      }
+      else {
+        js_val = js_obj;
+      }
+    }
+  }
+
+  if (js_val == NULL) {
+    return NULL;
+  }
+
+  return js_val;
+}
+
+static const char *
+get_js_string(const json_t *js, const char *key,
+              const char *delim, const char *quote)
+{
+  const char *val = NULL;
+  json_t *js_val = NULL;
+
+  if (!key || !strlen(key)) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  js_val = get_js_json(js, key, delim, quote);
+  if (js_val == NULL) {
+    errno = ENOENT;
+    return NULL;
+  }
+
+  if (json_typeof(js_val) == JSON_STRING) {
+    val = json_string_value(js_val);
+  }
+  else {
+    errno = EINVAL;
+  }
+
+  return val;
+}
+
+static long
+get_js_int(const json_t *js, const char *key,
+           const char *delim, const char *quote)
+{
+  long val = -1;
+  json_t *js_val = NULL;
+
+  if (!key || !strlen(key)) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  js_val = get_js_json(js, key, delim, quote);
+  if (js_val == NULL) {
+    errno = ENOENT;
+    return 0;
+  }
+
+  if (json_typeof(js_val) == JSON_INTEGER) {
+    val = (long) json_integer_value(js_val);
+  }
+  else {
+    errno = EINVAL;
+  }
+
+  return val;
+}
+
+static int
+get_js_bool(const json_t *js, const char *key,
+            const char *delim, const char *quote)
+{
+  int val = -1;
+  json_t *js_val = NULL;
+
+  if (!key || !strlen(key)) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  js_val = get_js_json(js, key, delim, quote);
+  if (js_val == NULL) {
+    errno = ENOENT;
+    return 0;
+  }
+
+  switch (json_typeof(js_val)) {
+    case JSON_TRUE:
+      val = 1;
+      break;
+    case JSON_FALSE:
+      val = 0;
+      break;
+    default:
+      errno = EINVAL;
+  }
+
+  return val;
+}
+
+const char *
+ngx_http_auth_jwt_get_header(jwt_t *jwt, const char *header,
+                             const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_header(jwt, header);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  errno = 0;
+
+  return get_js_string(jwt->headers, header, delim, quote);
+}
+
+long
+ngx_http_auth_jwt_get_header_int(jwt_t *jwt, const char *header,
+                                 const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_header_int(jwt, header);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  errno = 0;
+
+  return get_js_int(jwt->headers, header, delim, quote);
+}
+
+int
+ngx_http_auth_jwt_get_header_bool(jwt_t *jwt, const char *header,
+                                  const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_header_bool(jwt, header);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  errno = 0;
+
+  return get_js_bool(jwt->headers, header, delim, quote);
+}
+
+char *
+ngx_http_auth_jwt_get_headers_json(jwt_t *jwt, const char *header,
+                                   const char *delim, const char *quote)
+{
+  json_t *js_val = NULL;
+
+  if (delim == NULL) {
+    return jwt_get_headers_json(jwt, header);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  js_val = get_js_json(jwt->headers, header, delim, quote);
+  if (js_val == NULL) {
+    errno = ENOENT;
+    return NULL;
+  }
+
+  errno = 0;
+
+  return json_dumps(js_val, JSON_SORT_KEYS | JSON_COMPACT | JSON_ENCODE_ANY);
+}
+
+const char *
+ngx_http_auth_jwt_get_grant(jwt_t *jwt, const char *grant,
+                            const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_grant(jwt, grant);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  errno = 0;
+
+  return get_js_string(jwt->grants, grant, delim, quote);
+}
+
+long
+ngx_http_auth_jwt_get_grant_int(jwt_t *jwt, const char *grant,
+                                const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_grant_int(jwt, grant);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  errno = 0;
+
+  return get_js_int(jwt->grants, grant, delim, quote);
+}
+
+int
+ngx_http_auth_jwt_get_grant_bool(jwt_t *jwt, const char *grant,
+                                 const char *delim, const char *quote)
+{
+  if (delim == NULL) {
+    return jwt_get_grant_bool(jwt, grant);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return 0;
+  }
+
+  errno = 0;
+
+  return get_js_bool(jwt->grants, grant, delim, quote);
+}
+
+char *
+ngx_http_auth_jwt_get_grants_json(jwt_t *jwt, const char *grant,
+                                  const char *delim, const char *quote)
+{
+  json_t *js_val = NULL;
+
+  if (delim == NULL) {
+    return jwt_get_grants_json(jwt, grant);
+  }
+
+  if (!jwt) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  js_val = get_js_json(jwt->grants, grant, delim, quote);
+  if (js_val == NULL) {
+    errno = ENOENT;
+    return NULL;
+  }
+
+  errno = 0;
+
+  return json_dumps(js_val, JSON_SORT_KEYS | JSON_COMPACT | JSON_ENCODE_ANY);
+}

--- a/src/jwt_get_claims.h
+++ b/src/jwt_get_claims.h
@@ -1,0 +1,24 @@
+#ifndef JWK_GET_CLAIMS_H
+#define JWK_GET_CLAIMS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "jwt/jwt.h"
+
+const char *ngx_http_auth_jwt_get_header(jwt_t *jwt, const char *header, const char *delim, const char *quote);
+long ngx_http_auth_jwt_get_header_int(jwt_t *jwt, const char *header, const char *delim, const char *quote);
+int ngx_http_auth_jwt_get_header_bool(jwt_t *jwt, const char *header, const char *delim, const char *quote);
+char *ngx_http_auth_jwt_get_headers_json(jwt_t *jwt, const char *header, const char *delim, const char *quote);
+
+const char *ngx_http_auth_jwt_get_grant(jwt_t *jwt, const char *grant, const char *delim, const char *quote);
+long ngx_http_auth_jwt_get_grant_int(jwt_t *jwt, const char *grant, const char *delim, const char *quote);
+int ngx_http_auth_jwt_get_grant_bool(jwt_t *jwt, const char *grant, const char *delim, const char *quote);
+char *ngx_http_auth_jwt_get_grants_json(jwt_t *jwt, const char *grant, const char *delim, const char *quote);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JWK_GET_CLAIMS_H */

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -1813,7 +1813,7 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     }
 
     json_object_foreach(cf->revocation.subs, revocation_sub, value) {
-      if (strcmp(jwt_sub, revocation_sub) == 0) {
+      if (ngx_strcmp(jwt_sub, revocation_sub) == 0) {
         char *msg = json_dumps(value, JSON_COMPACT);
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "auth_jwt: rejected due to sub in revocation list"
@@ -1833,7 +1833,7 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     const char * revocation_kid;
 
     // note that revocation_kids turn on kid to required header
-    if (kid == NULL || strcmp(kid, "") == 0) {
+    if (kid == NULL || ngx_strcmp(kid, "") == 0) {
       ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                     "auth_jwt: rejected due to kid cannot be empty"
                     " when revocation_kids set", kid);
@@ -1841,7 +1841,7 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     }
 
     json_object_foreach(cf->revocation.kids, revocation_kid, value) {
-      if (strcmp(kid, revocation_kid) == 0) {
+      if (ngx_strcmp(kid, revocation_kid) == 0) {
         char *msg = json_dumps(value, JSON_COMPACT);
         ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                       "auth_jwt: rejected due to kid in revocation list"

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -662,7 +662,7 @@ ngx_http_auth_jwt_conf_set_token_variable(ngx_conf_t *cf,
 }
 
 static char *
-ngx_http_auth_jwt_conf_set_valiable(ngx_conf_t *cf,
+ngx_http_auth_jwt_conf_set_variable(ngx_conf_t *cf,
                                     ngx_command_t *cmd, void *conf,
                                     const char *prefix,
                                     ngx_http_get_variable_pt get_handler)
@@ -719,7 +719,7 @@ ngx_http_auth_jwt_conf_set_claim(ngx_conf_t *cf,
                                  ngx_command_t *cmd, void *conf)
 {
   return
-    ngx_http_auth_jwt_conf_set_valiable(cf, cmd, conf,
+    ngx_http_auth_jwt_conf_set_variable(cf, cmd, conf,
                                         NGX_HTTP_AUTH_JWT_CLAIM_VAR_PREFIX,
                                         ngx_http_auth_jwt_variable_claim);
 }
@@ -729,7 +729,7 @@ ngx_http_auth_jwt_conf_set_header(ngx_conf_t *cf,
                                   ngx_command_t *cmd, void *conf)
 {
   return
-    ngx_http_auth_jwt_conf_set_valiable(cf, cmd, conf,
+    ngx_http_auth_jwt_conf_set_variable(cf, cmd, conf,
                                         NGX_HTTP_AUTH_JWT_HEADER_VAR_PREFIX,
                                         ngx_http_auth_jwt_variable_header);
 }

--- a/t/auth_jwt_allow_nested.t
+++ b/t/auth_jwt_allow_nested.t
@@ -1,0 +1,258 @@
+use Test::Nginx::Socket 'no_plan';
+
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== require nested claim
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_access '["grants_access_admin"]';
+  auth_jwt_require_claim grants.access intersect $expected_access;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with multiple
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_access '["grants_access_admin"]';
+  auth_jwt_require_claim grants.access intersect $expected_access;
+  set $expected_roles '["grants_roles_admin"]';
+  auth_jwt_require_claim grants.roles intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with multiple stage
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["grants_service_roles_admin"]';
+  auth_jwt_require_claim grants.service.roles intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with invalid key
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["access_roles_admin"]';
+  auth_jwt_require_claim access.roles intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 401
+
+=== require nested claim with quote key
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["access_roles_admin"]';
+  auth_jwt_require_claim '"access.roles"' intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with quote key and multiple stage
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["access_roles_admin"]';
+  auth_jwt_require_claim '"access.roles"' intersect $expected_roles;
+  set $expected_access_roles '["grants_access_roles_admin"]';
+  auth_jwt_require_claim 'grants."access.roles"' intersect $expected_access_roles;
+  set $expected_service_roles '["grants_access_service_roles_admin"]';
+  auth_jwt_require_claim 'grants."access.service".roles' intersect $expected_service_roles;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with specify delimiter
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested delimiter=<>;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["grants_service_roles_admin"]';
+  auth_jwt_require_claim grants<>service<>roles intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== require nested claim with specify quote
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested delimiter=. quote=';
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_roles '["access_roles_admin"]';
+  auth_jwt_require_claim '"access.roles"' intersect $expected_roles;
+}
+--- request
+GET /
+--- error_code: 401
+
+=== require nested header
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  set $expected_access '["roles_access_admin"]';
+  auth_jwt_require_header roles.access intersect $expected_access;
+  set $expected_services '["roles_services_admin"]';
+  auth_jwt_require_header roles.services intersect $expected_services;
+}
+--- request
+GET /
+--- error_code: 200
+
+=== variable nested claim
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested delimiter=_;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  add_header 'X-Jwt-Claim-Sub' $jwt_claim_sub;
+  add_header 'X-Jwt-Claim-Roles' $jwt_claim_roles;
+  # variable name can only contain A-z, 0-9, and _
+  add_header 'X-Jwt-Claim-Grants-Access' $jwt_claim_grants_access;
+}
+--- request
+GET /
+--- response_headers
+X-Jwt-Claim-Sub: 1234567890
+X-Jwt-Claim-Roles: admin,user
+X-Jwt-Claim-Grants-Access: grants_access_admin,grants_access_user
+--- error_code: 200
+
+=== variable nested header
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested delimiter=_;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  add_header 'X-Jwt-Claim-Alg' $jwt_header_alg;
+  # variable name can only contain A-z, 0-9, and _
+  add_header 'X-Jwt-Claim-Roles-Access' $jwt_header_roles_access;
+}
+--- request
+GET /
+--- response_headers
+X-Jwt-Claim-Alg: HS256
+X-Jwt-Claim-Roles-Access: ["roles_access_admin","roles_access_user"]
+--- error_code: 200
+
+=== set variable nested claim
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+auth_jwt_claim_set $jwt_access grants.access;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  add_header 'X-Jwt-Claim-Sub' $jwt_claim_sub;
+  add_header 'X-Jwt-Claim-Roles' $jwt_claim_roles;
+  add_header 'X-Jwt-Claim-Grants-Access' $jwt_access;
+}
+--- request
+GET /
+--- response_headers
+X-Jwt-Claim-Sub: 1234567890
+X-Jwt-Claim-Roles: admin,user
+X-Jwt-Claim-Grants-Access: grants_access_admin,grants_access_user
+--- error_code: 200
+
+=== set variable nested header
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+auth_jwt_allow_nested;
+auth_jwt_header_set $jwt_access roles.access;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+location / {
+  auth_jwt "" token=$nested_jwt;
+  add_header 'X-Jwt-Claim-Alg' $jwt_header_alg;
+  add_header 'X-Jwt-Claim-Roles-Access' $jwt_access;
+}
+--- request
+GET /
+--- response_headers
+X-Jwt-Claim-Alg: HS256
+X-Jwt-Claim-Roles-Access: ["roles_access_admin","roles_access_user"]
+--- error_code: 200
+
+=== set allow nested on server
+--- http_config
+--- config
+auth_jwt_allow_nested;
+--- must_die
+
+=== set allow nested on location
+--- http_config
+--- config
+location / {
+  auth_jwt_allow_nested;
+}
+--- must_die

--- a/t/conf/jwt.conf
+++ b/t/conf/jwt.conf
@@ -78,3 +78,63 @@ set $require_claim_real_jwt "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6InRlc3Q
 #   "roles": ["admin", "service"],
 #   "iss": "issuer"
 # }
+
+set $nested_jwt "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6InRlc3QxIiwicm9sZXMiOiB7ImFjY2VzcyI6IFsicm9sZXNfYWNjZXNzX2FkbWluIiwicm9sZXNfYWNjZXNzX3VzZXIiXSwic2VydmljZXMiOiBbInJvbGVzX3NlcnZpY2VzX2FkbWluIiwicm9sZXNfc2VydmljZXNfdXNlciJdICB9fQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjogMTUxNjIzOTAyMiwiZXhwIjogNDEzMzg2MjAwMCwiaXNzIjoiaXNzdWVyIiwicm9sZXMiOiBbImFkbWluIiwidXNlciJdLCJhY2Nlc3Mucm9sZXMiOiBbImFjY2Vzc19yb2xlc19hZG1pbiIsImFjY2Vzc19yb2xlc191c2VyIl0sImdyYW50cyI6IHsiYWNjZXNzIjogWyJncmFudHNfYWNjZXNzX2FkbWluIiwiZ3JhbnRzX2FjY2Vzc191c2VyIl0sInJvbGVzIjogWyJncmFudHNfcm9sZXNfYWRtaW4iLCJncmFudHNfcm9sZXNfdXNlciJdLCJhY2Nlc3Mucm9sZXMiOiBbImdyYW50c19hY2Nlc3Nfcm9sZXNfYWRtaW4iLCJncmFudHNfYWNjZXNzX3JvbGVzX3VzZXIiXSwic2VydmljZSI6IHsicm9sZXMiOiBbImdyYW50c19zZXJ2aWNlX3JvbGVzX2FkbWluIiwiZ3JhbnRzX3NlcnZpY2Vfcm9sZXNfdXNlciJdfSwiYWNjZXNzLnNlcnZpY2UiOiB7InJvbGVzIjogWyJncmFudHNfYWNjZXNzX3NlcnZpY2Vfcm9sZXNfYWRtaW4iLCJncmFudHNfYWNjZXNzX3NlcnZpY2Vfcm9sZXNfdXNlciJdfSAgfX0.Q15Qern7eUsFJJfWcfBlTFj_4ExlqV-aJ-MRTw3tM_U";
+# HEADER:DATA
+# {
+#   "typ": "JWT",
+#   "alg": "HS256",
+#   "kid": "test1",
+#   "roles": {
+#     "access": [
+#       "roles_access_admin",
+#       "roles_access_user"
+#     ],
+#     "services": [
+#       "roles_services_admin",
+#       "roles_services_user"
+#     ]
+#   }
+# }
+# PAYLOAD:DATA
+# {
+#   "sub": "1234567890",
+#   "name": "John Doe",
+#   "iat": 1516239022,
+#   "exp": 4133862000,
+#   "iss": "issuer",
+#   "roles": [
+#     "admin",
+#     "user"
+#   ],
+#   "access.roles": [
+#     "access_roles_admin",
+#     "access_roles_user"
+#   ],
+#   "grants": {
+#     "access": [
+#       "grants_access_admin",
+#       "grants_access_user"
+#     ],
+#     "roles": [
+#       "grants_roles_admin",
+#       "grants_roles_user"
+#     ],
+#     "access.roles": [
+#       "grants_access_roles_admin",
+#       "grants_access_roles_user"
+#     ],
+#     "service": {
+#       "roles": [
+#         "grants_service_roles_admin",
+#         "grants_service_roles_user"
+#       ]
+#     },
+#     "access.service": {
+#       "roles": [
+#         "grants_access_service_roles_admin",
+#         "grants_access_service_roles_user"
+#       ]
+#     }
+#   }
+# }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a directive `auth_jwt_allow_nested` to support nested claims/headers in JWT tokens.
	- Added support for new JWT algorithms (PS256, PS384, PS512) and enhanced RSA operations.
	- Implemented functions for extracting and manipulating JSON data from JWT claims.
- **Documentation**
	- Updated README and source files with new directive documentation and updated library references.
- **Refactor**
	- Updated source references and corrected typos in comments.
	- Enhanced error handling and validation messages in JWT processing.
- **Tests**
	- Added test cases for nested JWT claims and headers authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->