### PR TITLE
feat: Fix NULL warning

### DIFF
--- a/src/jwt/jwt.c
+++ b/src/jwt/jwt.c
@@ -589,7 +589,7 @@ int jwt_parse(jwt_t **jwt, const char *token, unsigned int *len)
 {
 	char *head = NULL;
 	jwt_t *new = NULL;
-	char *body, *sig;
+	char *body, *sig = NULL;
 	int ret = EINVAL;
 
 	if (!jwt)


### PR DESCRIPTION
There is a initialization warning preventing build by nix package manager. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved variable management in the JWT parsing function to prevent potential issues related to uninitialized variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->