### PR TITLE
fix: uninitialized struct field in ngx_http_auth_jwt_set_bearer_header()

### DIFF
--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -1519,6 +1519,7 @@ ngx_http_auth_jwt_set_bearer_header(ngx_http_request_t *r,
   }
 
   r->headers_out.www_authenticate->hash = 1;
+  r->headers_out.www_authenticate->next = NULL;
   ngx_str_set(&r->headers_out.www_authenticate->key, "WWW-Authenticate");
   r->headers_out.www_authenticate->value.data = bearer;
   r->headers_out.www_authenticate->value.len = len;


### PR DESCRIPTION
The uninitialized `next` field was later referenced from http core module [here](https://github.com/nginx/nginx/blob/release-1.25.5/src/http/ngx_http_core_module.c#L1126) if the `satisfy any` directive was used in conjunction with `auth_jwt`, which resulted in the SIGSEGV to the worker process and the following log line:

2025/02/21 07:18:30 [alert] 7#7: worker process 8 exited on signal 11 (core dumped)

```
$ gdb /usr/bin/nginx /cores/core-nginx.8.1740122310 

[...]

Core was generated by `nginx: worker process                  '.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055555560d639 in ngx_http_core_access_phase (r=0x7ffff78ec9f0, ph=0x7ffff78a4eb0)
    at src/http/ngx_http_core_module.c:1127
1127	                h->hash = 0;
[Current thread is 1 (LWP 8)]

[...]

(gdb) bt
#0  0x000055555560d639 in ngx_http_core_access_phase (r=0x7ffff78ec9f0, ph=0x7ffff78a4eb0)
    at src/http/ngx_http_core_module.c:1127
#1  0x000055555560cbc8 in ngx_http_core_run_phases (r=0x7ffff78ec9f0)
    at src/http/ngx_http_core_module.c:875
#2  0x000055555560cb32 in ngx_http_handler (r=0x7ffff78ec9f0)
    at src/http/ngx_http_core_module.c:858
#3  0x000055555561e286 in ngx_http_process_request (r=0x7ffff78ec9f0)
    at src/http/ngx_http_request.c:2140
#4  0x000055555561c918 in ngx_http_process_request_headers (rev=0x7ffff5e411f0)
    at src/http/ngx_http_request.c:1529
#5  0x000055555561bc8d in ngx_http_process_request_line (rev=0x7ffff5e411f0)
    at src/http/ngx_http_request.c:1196
#6  0x000055555561a1bd in ngx_http_wait_request_handler (rev=0x7ffff5e411f0)
    at src/http/ngx_http_request.c:523
#7  0x00005555555cf797 in ngx_epoll_process_events (cycle=0x7ffff799f1d0, timer=60000, 
    flags=1) at src/event/modules/ngx_epoll_module.c:901
#8  0x00005555555ba4a3 in ngx_process_events_and_timers (cycle=0x7ffff799f1d0)
    at src/event/ngx_event.c:248
#9  0x00005555555cc5b0 in ngx_worker_process_cycle (cycle=0x7ffff799f1d0, data=0x0)
    at src/os/unix/ngx_process_cycle.c:721
#10 0x00005555555c88b5 in ngx_spawn_process (cycle=0x7ffff799f1d0, 
    proc=0x5555555cc4b1 <ngx_worker_process_cycle>, data=0x0, 
    name=0x5555556fd0b2 "worker process", respawn=-3) at src/os/unix/ngx_process.c:199
#11 0x00005555555cb26a in ngx_start_worker_processes (cycle=0x7ffff799f1d0, n=1, type=-3)
    at src/os/unix/ngx_process_cycle.c:344
#12 0x00005555555ca877 in ngx_master_process_cycle (cycle=0x7ffff799f1d0)
    at src/os/unix/ngx_process_cycle.c:130
#13 0x000055555557f2d3 in main (argc=3, argv=0x7fffffffec98) at src/core/nginx.c:384
(gdb) l
1122	    } else {
1123	        if (rc == NGX_OK) {
1124	            r->access_code = 0;
1125	
1126	            for (h = r->headers_out.www_authenticate; h; h = h->next) {
1127	                h->hash = 0;
1128	            }
1129	
1130	            r->phase_handler = ph->next;
1131	            return NGX_AGAIN;
(gdb) p/x h->hash
Cannot access memory at address 0x10
(gdb) p/x *r->headers_out.www_authenticate
$2 = {hash = 0x0, key = {len = 0x10, data = 0x7ffff798a8d0}, value = {len = 0x19, 
    data = 0x7ffff78ed7d0}, lowcase_key = 0x0, next = 0x10}
(gdb) p/x r->headers_out.www_authenticate->next
$3 = 0x10
(gdb) q
```
More info:
```
/etc/nginx $ ldd /usr/bin/nginx 
	/lib/ld-musl-x86_64.so.1 (0x7ffff7f59000)
	libpcre.so.1 => /usr/lib/libpcre.so.1 (0x7ffff7c37000)
	libssl.so.3 => /usr/lib/libssl.so.3 (0x7ffff7b74000)
	libcrypto.so.3 => /usr/lib/libcrypto.so.3 (0x7ffff7728000)
	libz.so.1 => /usr/lib/libz.so.1 (0x7ffff770d000)
	libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7ffff7f59000)

/etc/nginx $ cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.21.0
PRETTY_NAME="Alpine Linux v3.21"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"

/etc/nginx $ nginx -V
nginx version: nginx/1.25.5
built by gcc 14.2.0 (Alpine 14.2.0) 
built with OpenSSL 3.3.3 11 Feb 2025
TLS SNI support enabled
configure arguments: --prefix=/usr/local/nginx --conf-path=/etc/nginx/nginx.conf --modules-path=/etc/nginx/modules --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock --pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body --http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy --http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi --with-debug --with-compat --with-pcre-jit --with-http_ssl_module --with-http_stub_status_module --with-http_realip_module --with-http_auth_request_module --with-http_addition_module --with-http_gzip_static_module --with-http_sub_module --with-http_v2_module --with-http_v3_module --with-stream --with-stream_ssl_module --with-stream_realip_module --with-stream_ssl_preread_module --with-threads --with-http_secure_link_module --with-http_gunzip_module --with-file-aio --without-mail_pop3_module --without-mail_smtp_module --without-mail_imap_module --without-http_uwsgi_module --without-http_scgi_module --with-cc-opt='-g -O0 -fPIE -fstack-protector-strong -Wformat -Werror=format-security -Wno-deprecated-declarations -fno-strict-aliasing -D_FORTIFY_SOURCE=2 --param=ssp-buffer-size=4 -DTCP_FASTOPEN=23 -fPIC -Wno-cast-function-type -m64 -mtune=generic' --with-ld-opt='-fPIE -fPIC -pie -Wl,-z,relro -Wl,-z,now' --user=www-data --group=www-data --add-dynamic-module=../nginx-auth-jwt-0.9.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced response header handling to ensure proper termination of header lists, improving the reliability of header processing. This update prevents potential issues when dealing with multiple headers, contributing to overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->