### PR TITLE
feat: add $jwt_status and $jwt_status_code variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ location / {
 - [auth\_jwt\_require\_claim](#auth_jwt_require_claim)
 - [auth\_jwt\_require\_header](#auth_jwt_require_header)
 - [auth\_jwt\_allow\_nested](#auth_jwt_allow_nested)
+- [auth\_jwt\_allow\_failed](#auth_jwt_allow_failed)
 
 <a name="auth_jwt"></a>
 ```
@@ -468,6 +469,47 @@ The optional `quote` parameter sets the quote character for the key
 > }
 > ```
 
+<a name="auth_jwt_allow_failed"></a>
+```
+Syntax: auth_jwt_allow_failed on | off;
+Default: auth_jwt_allow_failed off;
+Context: http, server, location, limit_except
+```
+
+When enabled, JWT validation failures will not block the request.
+Instead, the request continues and the validation result is available
+via `$jwt_status` and `$jwt_status_code` variables.
+
+This allows custom handling of authentication failures using `if` directives
+or passing the status to backend services.
+
+> Examples:
+> ```
+> location /api/ {
+>     auth_jwt "API";
+>     auth_jwt_key_file /etc/nginx/keys.jwks;
+>     auth_jwt_allow_failed on;
+>
+>     # Custom handling based on JWT status
+>     if ($jwt_status != "ok") {
+>         return 401 "JWT validation failed: $jwt_status";
+>     }
+>
+>     proxy_pass http://backend;
+> }
+>
+> location /mixed/ {
+>     auth_jwt "Mixed";
+>     auth_jwt_key_file /etc/nginx/keys.jwks;
+>     auth_jwt_allow_failed on;
+>
+>     # Pass JWT status to backend
+>     proxy_set_header X-JWT-Status $jwt_status;
+>     proxy_set_header X-JWT-Status-Code $jwt_status_code;
+>     proxy_pass http://backend;
+> }
+> ```
+
 ### Embedded Variables
 
 The module supports embedded variables:
@@ -496,6 +538,33 @@ $jwt_nowtime
 ```
 
 Returns the value of now timestamp.
+
+```
+$jwt_status
+```
+
+Returns the JWT validation status as a string. Possible values:
+- `ok` - JWT validation successful
+- `bypass` - JWT validation bypassed
+- `no_token` - No JWT token provided
+- `invalid_token` - JWT token could not be parsed
+- `expired` - JWT token has expired
+- `not_yet_valid` - JWT token is not yet valid (nbf claim)
+- `revoked_sub` - JWT subject is in revocation list
+- `revoked_kid` - JWT key ID is in revocation list
+- `claim_required` - Required claim is missing or invalid
+- `header_required` - Required header is missing or invalid
+- `var_required` - Required variable validation failed
+- `sig_invalid` - JWT signature validation failed
+- `no_key` - No signing key available for validation
+- `alg_none` - Algorithm "none" is not allowed
+- `error` - Internal error occurred
+
+```
+$jwt_status_code
+```
+
+Returns the HTTP status code corresponding to the JWT validation result (e.g., `200`, `401`, `500`).
 
 Example
 -------

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -12,10 +12,49 @@
 #define NGX_HTTP_AUTH_JWT_CLAIM_VAR_PREFIX "jwt_claim_"
 #define NGX_HTTP_AUTH_JWT_HEADER_VAR_PREFIX "jwt_header_"
 
+/* JWT validation status codes */
+typedef enum {
+  NGX_HTTP_AUTH_JWT_STATUS_OK = 0,
+  NGX_HTTP_AUTH_JWT_STATUS_BYPASS,
+  NGX_HTTP_AUTH_JWT_STATUS_NO_TOKEN,
+  NGX_HTTP_AUTH_JWT_STATUS_INVALID_TOKEN,
+  NGX_HTTP_AUTH_JWT_STATUS_EXPIRED,
+  NGX_HTTP_AUTH_JWT_STATUS_NOT_YET_VALID,
+  NGX_HTTP_AUTH_JWT_STATUS_REVOKED_SUB,
+  NGX_HTTP_AUTH_JWT_STATUS_REVOKED_KID,
+  NGX_HTTP_AUTH_JWT_STATUS_CLAIM_REQUIRED,
+  NGX_HTTP_AUTH_JWT_STATUS_HEADER_REQUIRED,
+  NGX_HTTP_AUTH_JWT_STATUS_VAR_REQUIRED,
+  NGX_HTTP_AUTH_JWT_STATUS_SIG_INVALID,
+  NGX_HTTP_AUTH_JWT_STATUS_NO_KEY,
+  NGX_HTTP_AUTH_JWT_STATUS_ALG_NONE,
+  NGX_HTTP_AUTH_JWT_STATUS_ERROR
+} ngx_http_auth_jwt_status_t;
+
+static const char *ngx_http_auth_jwt_status_strings[] = {
+  "ok",
+  "bypass",
+  "no_token",
+  "invalid_token",
+  "expired",
+  "not_yet_valid",
+  "revoked_sub",
+  "revoked_kid",
+  "claim_required",
+  "header_required",
+  "var_required",
+  "sig_invalid",
+  "no_key",
+  "alg_none",
+  "error"
+};
+
 static ngx_int_t ngx_http_auth_jwt_variable_claim(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_auth_jwt_variable_header(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_auth_jwt_variable_claims(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_auth_jwt_variable_nowtime(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_auth_jwt_variable_status(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
+static ngx_int_t ngx_http_auth_jwt_variable_status_code(ngx_http_request_t *r, ngx_http_variable_value_t *v, uintptr_t data);
 
 static char *ngx_http_auth_jwt_conf_set_token_variable(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_auth_jwt_conf_set_claim(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
@@ -46,6 +85,7 @@ typedef struct {
   time_t leeway;
   ngx_int_t phase;
   ngx_flag_t enabled;
+  ngx_flag_t allow_failed;
   ngx_str_t realm;
   struct {
     json_t *subs;
@@ -89,6 +129,8 @@ typedef struct {
   jwt_t *jwt;
   json_t *keys;
   ngx_int_t status;
+  ngx_http_auth_jwt_status_t jwt_status;
+  ngx_int_t http_status;
 } ngx_http_auth_jwt_ctx_t;
 
 typedef struct {
@@ -149,6 +191,18 @@ static ngx_http_variable_t ngx_http_auth_jwt_vars[] = {
   { ngx_string("jwt_nowtime"),
     NULL,
     ngx_http_auth_jwt_variable_nowtime,
+    0,
+    NGX_HTTP_VAR_NOCACHEABLE,
+    0 },
+  { ngx_string("jwt_status"),
+    NULL,
+    ngx_http_auth_jwt_variable_status,
+    0,
+    NGX_HTTP_VAR_NOCACHEABLE,
+    0 },
+  { ngx_string("jwt_status_code"),
+    NULL,
+    ngx_http_auth_jwt_variable_status_code,
     0,
     NGX_HTTP_VAR_NOCACHEABLE,
     0 },
@@ -256,6 +310,13 @@ static ngx_command_t ngx_http_auth_jwt_commands[] = {
     ngx_http_auth_jwt_conf_set_allow_nested,
     NGX_HTTP_LOC_CONF_OFFSET,
     0,
+    NULL },
+  { ngx_string("auth_jwt_allow_failed"),
+    NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LMT_CONF
+    |NGX_CONF_TAKE1,
+    ngx_conf_set_flag_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(ngx_http_auth_jwt_loc_conf_t, allow_failed),
     NULL },
   ngx_null_command
 };
@@ -664,6 +725,64 @@ ngx_http_auth_jwt_variable_nowtime(ngx_http_request_t *r,
 
   v->len = ngx_sprintf(v->data, "%ui", now) - v->data;
 
+  v->valid = 1;
+  v->no_cacheable = 0;
+  v->not_found = 0;
+
+  return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_auth_jwt_variable_status(ngx_http_request_t *r,
+                                  ngx_http_variable_value_t *v,
+                                  uintptr_t data)
+{
+  ngx_http_auth_jwt_ctx_t *ctx;
+  const char *status_str;
+  size_t len;
+
+  ctx = ngx_http_auth_jwt_get_module_ctx(r);
+  if (ctx == NULL) {
+    v->not_found = 1;
+    return NGX_OK;
+  }
+
+  status_str = ngx_http_auth_jwt_status_strings[ctx->jwt_status];
+  len = ngx_strlen(status_str);
+
+  v->data = ngx_pnalloc(r->pool, len);
+  if (v->data == NULL) {
+    return NGX_ERROR;
+  }
+
+  ngx_memcpy(v->data, status_str, len);
+  v->len = len;
+  v->valid = 1;
+  v->no_cacheable = 0;
+  v->not_found = 0;
+
+  return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_auth_jwt_variable_status_code(ngx_http_request_t *r,
+                                       ngx_http_variable_value_t *v,
+                                       uintptr_t data)
+{
+  ngx_http_auth_jwt_ctx_t *ctx;
+
+  ctx = ngx_http_auth_jwt_get_module_ctx(r);
+  if (ctx == NULL) {
+    v->not_found = 1;
+    return NGX_OK;
+  }
+
+  v->data = ngx_pnalloc(r->pool, sizeof("500") - 1);
+  if (v->data == NULL) {
+    return NGX_ERROR;
+  }
+
+  v->len = ngx_sprintf(v->data, "%i", ctx->http_status) - v->data;
   v->valid = 1;
   v->no_cacheable = 0;
   v->not_found = 0;
@@ -1239,6 +1358,7 @@ ngx_http_auth_jwt_create_loc_conf(ngx_conf_t *cf)
   conf->nested.quote = NULL;
 
   conf->enabled = NGX_CONF_UNSET;
+  conf->allow_failed = NGX_CONF_UNSET;
 
   return conf;
 }
@@ -1384,6 +1504,7 @@ ngx_http_auth_jwt_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
   ngx_conf_merge_value(conf->validate.sig, prev->validate.sig, 1);
 
   ngx_conf_merge_value(conf->enabled, prev->enabled, 0);
+  ngx_conf_merge_value(conf->allow_failed, prev->allow_failed, 0);
   ngx_conf_merge_str_value(conf->realm, prev->realm, "");
 
   if (prev->revocation.subs) {
@@ -1545,8 +1666,10 @@ ngx_http_auth_jwt_response(ngx_http_request_t *r,
 }
 
 #define ngx_http_auth_jwt_http_ok() ngx_http_auth_jwt_response(r, cf, ctx, 0, NGX_OK)
-#define ngx_http_auth_jwt_http_error_without_token() ngx_http_auth_jwt_response(r, cf, ctx, 0, ctx->status != 0 ? ctx->status : NGX_HTTP_UNAUTHORIZED)
-#define ngx_http_auth_jwt_http_error() ngx_http_auth_jwt_response(r, cf, ctx, 1, ctx->status != 0 ? ctx->status : NGX_HTTP_UNAUTHORIZED)
+#define ngx_http_auth_jwt_http_error_without_token() \
+  (cf->allow_failed ? NGX_OK : ngx_http_auth_jwt_response(r, cf, ctx, 0, ctx->status != 0 ? ctx->status : NGX_HTTP_UNAUTHORIZED))
+#define ngx_http_auth_jwt_http_error() \
+  (cf->allow_failed ? NGX_OK : ngx_http_auth_jwt_response(r, cf, ctx, 1, ctx->status != 0 ? ctx->status : NGX_HTTP_UNAUTHORIZED))
 
 static ngx_int_t
 ngx_http_auth_jwt_key_request_handler(ngx_http_request_t *r,
@@ -1737,6 +1860,9 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
   ngx_http_complex_value_t *var;
 
   if (!cf->validate.variable.values) {
+    /* validation successful - set OK status */
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_OK;
+    ctx->http_status = NGX_HTTP_OK;
     return NGX_OK;
   }
 
@@ -1749,6 +1875,8 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
       ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "auth_jwt: variable specified was not provided: %V",
                     &(var[i].value));
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_VAR_REQUIRED;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
 
@@ -1758,10 +1886,16 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
                     "auth_jwt: rejected due to %V variable invalid",
                     &(var[i].value));
       ctx->status = cf->validate.variable.error;
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_VAR_REQUIRED;
+      ctx->http_status = cf->validate.variable.error != NGX_CONF_UNSET
+                         ? cf->validate.variable.error : NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
   }
 
+  /* validation successful - set OK status */
+  ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_OK;
+  ctx->http_status = NGX_HTTP_OK;
   return NGX_OK;
 }
 
@@ -1930,6 +2064,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
   if (!cf || !ctx) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "auth_jwt: rejected due to missing required arguments");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_ERROR;
+    ctx->http_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
     return NGX_ERROR;
   }
 
@@ -1941,6 +2077,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     const char *jwt_sub = jwt_get_grant(ctx->jwt, "sub");
 
     if (jwt_sub == NULL){
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_CLAIM_REQUIRED;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
 
@@ -1953,6 +2091,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
         if (msg) {
           free(msg);
         }
+        ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_REVOKED_SUB;
+        ctx->http_status = NGX_HTTP_UNAUTHORIZED;
         return NGX_ERROR;
       }
     }
@@ -1969,6 +2109,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
       ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                     "auth_jwt: rejected due to kid cannot be empty"
                     " when revocation_kids set", kid);
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_HEADER_REQUIRED;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
 
@@ -1981,6 +2123,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
         if (msg) {
           free(msg);
         }
+        ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_REVOKED_KID;
+        ctx->http_status = NGX_HTTP_UNAUTHORIZED;
         return NGX_ERROR;
       }
     }
@@ -1992,6 +2136,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
                                              &algorithm,
                                              ngx_http_auth_jwt_get_grants_json)
       != NGX_OK) {
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_CLAIM_REQUIRED;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return NGX_ERROR;
   }
 
@@ -2001,6 +2147,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
 
     exp = ngx_http_auth_jwt_get_grant_time(r, ctx->jwt, "exp", NULL, NULL);
     if (exp == -1) {
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_CLAIM_REQUIRED;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
 
@@ -2013,6 +2161,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
                     exp, now, exp + cf->leeway);
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                     "auth_jwt: token: \"%s\"", (char *) ctx->token);
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_EXPIRED;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return NGX_ERROR;
     }
   }
@@ -2023,6 +2173,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
                                              &algorithm,
                                              ngx_http_auth_jwt_get_headers_json)
       != NGX_OK) {
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_HEADER_REQUIRED;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return NGX_ERROR;
   }
 
@@ -2030,6 +2182,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
   if (algorithm == JWT_ALG_NONE) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "auth_jwt: rejected due to none algorithm");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_ALG_NONE;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return NGX_ERROR;
   }
 
@@ -2042,6 +2196,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
   if (!ctx->keys) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "auth_jwt: rejected due to without signature key");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_NO_KEY;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return NGX_ERROR;
   }
 
@@ -2082,6 +2238,8 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                 "auth_jwt: token: \"%s\"", (char *) ctx->token);
 
+  ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_SIG_INVALID;
+  ctx->http_status = NGX_HTTP_UNAUTHORIZED;
   return NGX_ERROR;
 }
 
@@ -2156,6 +2314,8 @@ ngx_http_auth_jwt_handler(ngx_http_request_t *r, ngx_int_t phase)
     if (variable->not_found) {
       ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "auth_jwt: token variable specified was not provided");
+      ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_NO_TOKEN;
+      ctx->http_status = NGX_HTTP_UNAUTHORIZED;
       return ngx_http_auth_jwt_http_error();
     }
     var.data = variable->data;
@@ -2174,6 +2334,8 @@ ngx_http_auth_jwt_handler(ngx_http_request_t *r, ngx_int_t phase)
   if (var.len == 0) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "auth_jwt: token was not provided");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_NO_TOKEN;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return ngx_http_auth_jwt_http_error_without_token();
   }
 
@@ -2181,6 +2343,8 @@ ngx_http_auth_jwt_handler(ngx_http_request_t *r, ngx_int_t phase)
   if (ctx->token == NULL) {
     ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
                   "auth_jwt: failed to allocate token");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_ERROR;
+    ctx->http_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
     return NGX_HTTP_INTERNAL_SERVER_ERROR;
   }
 
@@ -2189,6 +2353,8 @@ ngx_http_auth_jwt_handler(ngx_http_request_t *r, ngx_int_t phase)
       || ctx->jwt == NULL) {
     ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                   "auth_jwt: failed to parse jwt token");
+    ctx->jwt_status = NGX_HTTP_AUTH_JWT_STATUS_INVALID_TOKEN;
+    ctx->http_status = NGX_HTTP_UNAUTHORIZED;
     return ngx_http_auth_jwt_http_error();
   }
 


### PR DESCRIPTION
Add new nginx variables to expose JWT validation status:
- $jwt_status: string status (ok, no_token, invalid_token, expired, etc.)
- $jwt_status_code: HTTP status code (200, 401, 500)

Add auth_jwt_allow_failed directive to continue request processing on JWT validation failure, enabling custom error handling via if directives or passing status to backend services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration directive to allow requests when JWT validation fails
  * Introduced variables to expose JWT validation status and corresponding HTTP status codes for error handling and debugging

* **Documentation**
  * Updated documentation with new JWT failure handling directive and embedded variables with usage examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->