### PR TITLE
chore: remove duplicate align_var_def_star_style in uncrustify config

### DIFF
--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -82,13 +82,6 @@ align_var_struct_gap = 2          # Minimum spaces between type and name
 align_var_struct_thresh = 0       # No threshold limit for alignment
 
 # =============================================================================
-# Pointer Alignment (Section 3.5)
-# =============================================================================
-
-# Pointer style: type *name (star attached to name)
-align_var_def_star_style = 2      # 2 = right align (attach to name)
-
-# =============================================================================
 # Switch/Case (Section 3.6)
 # =============================================================================
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified code formatting configuration by removing pointer alignment style settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->