### PR TITLE
ci: update nginx test versions to 1.29.8 mainline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,7 +158,7 @@ jobs:
           - alpine
           - ubuntu
           - '1.28.3' # stable
-          - '1.29.7' # mainline
+          - '1.29.8' # mainline
     container:
       image: ${{ matrix.nginx == 'alpine' && 'alpine:latest' || null }}
       options: ${{ matrix.nginx == 'alpine' && '--init' || null }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->