### PR TITLE
Feat www authenticate customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [f90891e](../../commit/f90891e) - 2026-05-20
+
+### Added
+
+- New `auth_jwt_www_authenticate on | off | <string>` directive controlling the `WWW-Authenticate` response header. The DEFAULT mode keeps the existing `Bearer realm="<realm>"[, error="invalid_token"]` output, `off` suppresses the module's header so a named location reached through `error_page 401` can emit its own value without nginx comma-joining both headers, and any other value is compiled as an `ngx_http_complex_value_t` and written verbatim (with variable interpolation) when authentication fails. Unblocks deploying the module in front of an MCP Resource Server where the `WWW-Authenticate` format mandated by MCP Authorization (`resource_metadata`, `scope`, `error="insufficient_scope"`) cannot coexist with the module's realm-only challenge
+
 ## [4880419](../../commit/4880419) - 2026-05-15
 
 ### Changed

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -25,6 +25,7 @@ For complete configuration examples, see [EXAMPLES.md](EXAMPLES.md).
 | [auth_jwt_require_claim](#auth_jwt_require_claim) | http, server, location, limit_except |
 | [auth_jwt_require_header](#auth_jwt_require_header) | http, server, location, limit_except |
 | [auth_jwt_allow_nested](#auth_jwt_allow_nested) | http, server, location |
+| [auth_jwt_www_authenticate](#auth_jwt_www_authenticate) | http, server, location, limit_except |
 
 ### auth_jwt
 
@@ -416,6 +417,50 @@ JWT payload example:
   },
   "grants.key": "dot"
 }
+```
+
+### auth_jwt_www_authenticate
+
+```
+Syntax:  auth_jwt_www_authenticate on | off | string;
+Default: auth_jwt_www_authenticate on;
+Context: http, server, location, limit_except
+```
+
+Controls the `WWW-Authenticate` response header that the module appends to Bearer token requests on authentication failure.
+
+| Value | Behavior |
+|-------|----------|
+| `on` | Default behavior. Appends `Bearer realm="<realm>"`. When the token is invalid, also appends `, error="invalid_token"` |
+| `off` | The module does not append the `WWW-Authenticate` header. Use this when you want full control over the header through `error_page` to a named location with `add_header WWW-Authenticate ...` |
+| any string | Appends the given value as-is as the `WWW-Authenticate` header. Variables can be used |
+
+The header is appended only when the request carries an `Authorization: Bearer ...` header and the response is 401. If the request has no `Bearer ` prefix or the token came from a variable specified by the `token=` parameter, the header is not appended even when `on` is in effect (existing behavior).
+
+Suppressing with `off` and emitting from a named location:
+
+```nginx
+location /test {
+    auth_jwt "test";
+    auth_jwt_key_file /etc/nginx/keys/jwks.json;
+    auth_jwt_www_authenticate off;
+    error_page 401 = @test_unauthorized;
+    proxy_pass http://test_backend;
+}
+
+location @test_unauthorized {
+    internal;
+    add_header WWW-Authenticate
+        'Bearer resource_metadata="$test_metadata_uri", scope="$test_required_scope"'
+        always;
+    return 401;
+}
+```
+
+Emitting directly via a custom string with variables:
+
+```nginx
+auth_jwt_www_authenticate 'Bearer resource_metadata="$test_metadata_uri", scope="$test_required_scope"';
 ```
 
 ## Embedded Variables

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -46,6 +46,10 @@ static ngx_int_t ngx_http_auth_jwt_decode_token(ngx_http_request_t *r,
 #define NGX_HTTP_AUTH_JWT_CLAIM_VAR_PREFIX "jwt_claim_"
 #define NGX_HTTP_AUTH_JWT_HEADER_VAR_PREFIX "jwt_header_"
 
+#define NGX_HTTP_AUTH_JWT_WWW_AUTH_DEFAULT 0
+#define NGX_HTTP_AUTH_JWT_WWW_AUTH_OFF     1
+#define NGX_HTTP_AUTH_JWT_WWW_AUTH_CUSTOM  2
+
 static ngx_int_t ngx_http_auth_jwt_variable_claim(ngx_http_request_t *r,
     ngx_http_variable_value_t *v, uintptr_t data);
 static ngx_int_t ngx_http_auth_jwt_variable_header(ngx_http_request_t *r,
@@ -72,6 +76,8 @@ static char * ngx_http_auth_jwt_conf_set_requirement(ngx_conf_t *cf,
 static char *ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 static char *ngx_http_auth_jwt_conf_set_allow_nested(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+static char *ngx_http_auth_jwt_conf_set_www_authenticate(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 
 static ngx_int_t ngx_http_auth_jwt_pre_conf(ngx_conf_t *cf);
@@ -121,6 +127,10 @@ typedef struct {
         char *delimiter;
         char *quote;
     } nested;
+    struct {
+        ngx_int_t                 mode;
+        ngx_http_complex_value_t *value;
+    } www_authenticate;
 } ngx_http_auth_jwt_loc_conf_t;
 
 typedef struct {
@@ -328,6 +338,14 @@ static ngx_command_t ngx_http_auth_jwt_commands[] = {
       NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF
       | NGX_CONF_NOARGS | NGX_CONF_TAKE1 | NGX_CONF_TAKE2,
       ngx_http_auth_jwt_conf_set_allow_nested,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+    { ngx_string("auth_jwt_www_authenticate"),
+      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF |
+      NGX_HTTP_LMT_CONF
+      | NGX_CONF_TAKE1,
+      ngx_http_auth_jwt_conf_set_www_authenticate,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
@@ -1314,6 +1332,51 @@ ngx_http_auth_jwt_conf_set_allow_nested(ngx_conf_t *cf,
     return NGX_CONF_OK;
 }
 
+
+static char *
+ngx_http_auth_jwt_conf_set_www_authenticate(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf)
+{
+    ngx_http_auth_jwt_loc_conf_t *lcf = conf;
+    ngx_str_t *value;
+    ngx_http_compile_complex_value_t ccv;
+
+    if (lcf->www_authenticate.mode != NGX_CONF_UNSET) {
+        return "is duplicate";
+    }
+
+    value = cf->args->elts;
+
+    if (ngx_strcmp(value[1].data, "on") == 0) {
+        lcf->www_authenticate.mode = NGX_HTTP_AUTH_JWT_WWW_AUTH_DEFAULT;
+        return NGX_CONF_OK;
+    }
+
+    if (ngx_strcmp(value[1].data, "off") == 0) {
+        lcf->www_authenticate.mode = NGX_HTTP_AUTH_JWT_WWW_AUTH_OFF;
+        return NGX_CONF_OK;
+    }
+
+    lcf->www_authenticate.value = ngx_palloc(cf->pool,
+                                             sizeof(ngx_http_complex_value_t));
+    if (lcf->www_authenticate.value == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+    ccv.cf = cf;
+    ccv.value = &value[1];
+    ccv.complex_value = lcf->www_authenticate.value;
+
+    if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    lcf->www_authenticate.mode = NGX_HTTP_AUTH_JWT_WWW_AUTH_CUSTOM;
+
+    return NGX_CONF_OK;
+}
+
 static ngx_int_t
 ngx_http_auth_jwt_pre_conf(ngx_conf_t *cf)
 {
@@ -1382,6 +1445,9 @@ ngx_http_auth_jwt_create_loc_conf(ngx_conf_t *cf)
     conf->validate.sig = NGX_CONF_UNSET;
     conf->nested.delimiter = NULL;
     conf->nested.quote = NULL;
+
+    conf->www_authenticate.mode = NGX_CONF_UNSET;
+    conf->www_authenticate.value = NULL;
 
     conf->enabled = NGX_CONF_UNSET;
 
@@ -1587,6 +1653,15 @@ ngx_http_auth_jwt_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         }
     }
 
+    if (conf->www_authenticate.mode == NGX_CONF_UNSET) {
+        if (prev->www_authenticate.mode != NGX_CONF_UNSET) {
+            conf->www_authenticate.mode = prev->www_authenticate.mode;
+            conf->www_authenticate.value = prev->www_authenticate.value;
+        } else {
+            conf->www_authenticate.mode = NGX_HTTP_AUTH_JWT_WWW_AUTH_DEFAULT;
+        }
+    }
+
     return NGX_CONF_OK;
 }
 
@@ -1647,17 +1722,47 @@ ngx_http_auth_jwt_cleanup(void *data)
 
 static ngx_int_t
 ngx_http_auth_jwt_set_bearer_header(ngx_http_request_t *r,
-    ngx_str_t *realm, ngx_int_t error)
+    ngx_http_auth_jwt_loc_conf_t *cf, ngx_int_t error)
 {
     size_t len;
     u_char *bearer, *p;
+    ngx_str_t custom;
+
+    if (cf->www_authenticate.mode == NGX_HTTP_AUTH_JWT_WWW_AUTH_OFF) {
+        return NGX_OK;
+    }
+
+    if (cf->www_authenticate.mode == NGX_HTTP_AUTH_JWT_WWW_AUTH_CUSTOM) {
+        if (ngx_http_complex_value(r, cf->www_authenticate.value, &custom)
+            != NGX_OK)
+        {
+            return NGX_ERROR;
+        }
+
+        if (custom.len == 0) {
+            return NGX_OK;
+        }
+
+        r->headers_out.www_authenticate =
+            ngx_list_push(&r->headers_out.headers);
+        if (r->headers_out.www_authenticate == NULL) {
+            return NGX_ERROR;
+        }
+
+        r->headers_out.www_authenticate->hash = 1;
+        r->headers_out.www_authenticate->next = NULL;
+        ngx_str_set(&r->headers_out.www_authenticate->key, "WWW-Authenticate");
+        r->headers_out.www_authenticate->value = custom;
+
+        return NGX_OK;
+    }
 
     r->headers_out.www_authenticate = ngx_list_push(&r->headers_out.headers);
     if (r->headers_out.www_authenticate == NULL) {
         return NGX_ERROR;
     }
 
-    len = sizeof("Bearer realm=\"\"") - 1 + realm->len;
+    len = sizeof("Bearer realm=\"\"") - 1 + cf->realm.len;
     if (error) {
         len += sizeof(", error=\"invalid_token\"") - 1;
     }
@@ -1670,7 +1775,7 @@ ngx_http_auth_jwt_set_bearer_header(ngx_http_request_t *r,
     }
 
     p = ngx_cpymem(bearer, "Bearer realm=\"", sizeof("Bearer realm=\"") - 1);
-    p = ngx_cpymem(p, realm->data, realm->len);
+    p = ngx_cpymem(p, cf->realm.data, cf->realm.len);
     if (error) {
         p = ngx_cpymem(p, "\", error=\"invalid_token\"",
                        sizeof("\", error=\"invalid_token\"") - 1);
@@ -1694,7 +1799,7 @@ ngx_http_auth_jwt_response(ngx_http_request_t *r,
     ngx_int_t use_error, ngx_int_t code)
 {
     if (ctx->use_bearer) {
-        if (ngx_http_auth_jwt_set_bearer_header(r, &cf->realm,
+        if (ngx_http_auth_jwt_set_bearer_header(r, cf,
                                                 use_error) != NGX_OK)
         {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,

--- a/t/auth_jwt_www_authenticate.t
+++ b/t/auth_jwt_www_authenticate.t
@@ -1,0 +1,208 @@
+use Test::Nginx::Socket 'no_plan';
+
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== default (on) emits Bearer realm with error
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate: Bearer realm="test-realm", error="invalid_token"
+--- error_code: 401
+
+=== explicit on emits Bearer realm with error
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate on;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate: Bearer realm="test-realm", error="invalid_token"
+--- error_code: 401
+
+=== off suppresses header on invalid token
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate off;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate:
+--- error_code: 401
+
+=== off suppresses header when token missing
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate off;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- response_headers
+WWW-Authenticate:
+--- error_code: 401
+
+=== custom value not emitted when token missing
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate 'Bearer error="missing"';
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- response_headers
+WWW-Authenticate:
+--- error_code: 401
+
+=== custom static value
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate 'Bearer resource_metadata="https://rs.example.com/.well-known/oauth-protected-resource", scope="mcp:read"';
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate: Bearer resource_metadata="https://rs.example.com/.well-known/oauth-protected-resource", scope="mcp:read"
+--- error_code: 401
+
+=== custom value with variable
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+set $mcp_scope "mcp:read";
+set $mcp_metadata "https://rs.example.com/.well-known/oauth-protected-resource";
+location / {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate 'Bearer resource_metadata="$mcp_metadata", scope="$mcp_scope"';
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate: Bearer resource_metadata="https://rs.example.com/.well-known/oauth-protected-resource", scope="mcp:read"
+--- error_code: 401
+
+=== off suppresses header through error_page named location
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+location /mcp {
+  auth_jwt "test-realm";
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate off;
+  error_page 401 = @mcp_unauthorized;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+location @mcp_unauthorized {
+  internal;
+  add_header WWW-Authenticate 'Bearer resource_metadata="https://rs.example.com/meta", scope="mcp:read"' always;
+  return 401;
+}
+--- request
+GET /mcp
+--- more_headers
+Authorization: Bearer TOKEN
+--- response_headers
+WWW-Authenticate: Bearer resource_metadata="https://rs.example.com/meta", scope="mcp:read"
+--- error_code: 401
+
+=== inherit from server with location override
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+auth_jwt_www_authenticate off;
+location / {
+  auth_jwt "test-realm";
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+location /strict {
+  auth_jwt "strict-realm";
+  auth_jwt_www_authenticate on;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request eval
+[
+  "GET /",
+  "GET /strict"
+]
+--- more_headers eval
+[
+  "Authorization: Bearer TOKEN",
+  "Authorization: Bearer TOKEN"
+]
+--- response_headers eval
+[
+  "WWW-Authenticate:",
+  "WWW-Authenticate: Bearer realm=\"strict-realm\", error=\"invalid_token\""
+]
+--- error_code eval
+[
+  401,
+  401
+]
+
+=== off on successful auth still suppresses header
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_www_authenticate off;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request
+GET /
+--- response_headers
+WWW-Authenticate:
+--- error_code: 200


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auth_jwt_www_authenticate to control WWW-Authenticate on auth failures: default Bearer challenge, disable output, or emit custom strings with variable interpolation.

* **Documentation**
  * Updated changelog and directive docs with syntax, defaults, contexts, examples, and notes about when the header is emitted (e.g., Authorization: Bearer requests).

* **Tests**
  * Added tests covering default, disabled, and custom behaviors, inheritance, and interactions with error_page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/nginx-auth-jwt/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->