### PR TITLE
Scope error codes to individual auth_jwt_require directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [a0d109b](../../commit/a0d109b) - 2026-05-21
+
+### Fixed
+
+- Scope the `auth_jwt_require` `error=` parameter to its own directive. Previously the parsed error code was stored on a single location-wide field (`lcf->validate.variable.error`), so writing two directives such as `auth_jwt_require $aud_ok;` followed by `auth_jwt_require $scope_ok error=403;` made the second directive overwrite the first one's default 401 — a failed `$aud_ok` check returned 403, and the merge step inherited the same overwrite across nested locations. The require entries now hold their own `error` field (`ngx_http_auth_jwt_require_variable_t = { complex_value, error_code }`), the parser writes the directive-local `error=` (or the `NGX_HTTP_UNAUTHORIZED` default) onto every entry it pushes for that directive, and the validator returns the failing entry's status instead of a shared value. Single-directive configs keep the existing 401 / explicit `error=` behaviour; only multi-directive setups change. The redundant location-wide `error` field and its `create_loc_conf` / `merge_loc_conf` handling are removed, and the values array merge is updated to the new element type so prepend semantics for inherited directives stay intact
+
 ## [f90891e](../../commit/f90891e) - 2026-05-20
 
 ### Added

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -252,6 +252,8 @@ Specifies additional checks for JWT validation. The value can contain text, vari
 
 If any check fails, the 401 error code is returned. The optional `error` parameter allows redefining the error code to any HTTP status code in the range 400-599, excluding nginx internal codes 444 and 499.
 
+The `error` parameter only applies to the variables listed in the same directive. When the same scope contains multiple `auth_jwt_require` directives, each `error` is tracked independently and the response status comes from the directive whose check actually failed (or 401 when that directive omitted `error=`).
+
 ```nginx
 map $jwt_claim_iss $valid_jwt_iss {
     "good" 1;
@@ -261,6 +263,17 @@ location / {
     auth_jwt          "closed site";
     auth_jwt_key_file conf/keys.json;
     auth_jwt_require  $valid_jwt_iss;
+}
+```
+
+To map separate `auth_jwt_require` directives onto distinct HTTP status codes, write each directive individually. A failure of `$valid_aud` returns 401; a failure of `$valid_scope` returns 403.
+
+```nginx
+location / {
+    auth_jwt          "closed site";
+    auth_jwt_key_file conf/keys.json;
+    auth_jwt_require  $valid_aud;
+    auth_jwt_require  $valid_scope error=403;
 }
 ```
 

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -96,6 +96,11 @@ static ngx_int_t ngx_http_auth_jwt_handler(ngx_http_request_t *r,
 static void ngx_http_auth_jwt_cleanup(void *data);
 
 typedef struct {
+    ngx_http_complex_value_t  value;
+    ngx_int_t                 error;
+} ngx_http_auth_jwt_require_variable_t;
+
+typedef struct {
     ngx_int_t    token_variable;
     ngx_array_t *set_vars;
     time_t       leeway;
@@ -119,7 +124,6 @@ typedef struct {
             ngx_array_t *headers;
         } requirement;
         struct {
-            ngx_int_t    error;
             ngx_array_t *values;
         } variable;
     } validate;
@@ -1152,6 +1156,7 @@ ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
     ngx_http_auth_jwt_loc_conf_t *lcf;
     ngx_str_t *value;
     ngx_uint_t i, n;
+    ngx_int_t error_code = NGX_HTTP_UNAUTHORIZED;
     const char *error_with = "error=";
     const size_t error_with_len = sizeof("error=") - 1;
 
@@ -1161,7 +1166,8 @@ ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
 
     if (lcf->validate.variable.values == NULL) {
         lcf->validate.variable.values =
-            ngx_array_create(cf->pool, 4, sizeof(ngx_http_complex_value_t));
+            ngx_array_create(cf->pool, 4,
+                             sizeof(ngx_http_auth_jwt_require_variable_t));
         if (lcf->validate.variable.values == NULL) {
             return "failed to allocate memory for require";
         }
@@ -1173,11 +1179,11 @@ ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
         value[n].data += error_with_len;
         value[n].len -= error_with_len;
 
-        lcf->validate.variable.error = ngx_atoi(value[n].data, value[n].len);
-        if (lcf->validate.variable.error < 400
-            || lcf->validate.variable.error > 599
-            || lcf->validate.variable.error == 444
-            || lcf->validate.variable.error == 499)
+        error_code = ngx_atoi(value[n].data, value[n].len);
+        if (error_code < 400
+            || error_code > 599
+            || error_code == 444
+            || error_code == 499)
         {
             ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                "\"%V\" directive error code must be 400-599 "
@@ -1193,7 +1199,7 @@ ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
     }
 
     for (i = 1; i <= n; i++) {
-        ngx_http_complex_value_t *var;
+        ngx_http_auth_jwt_require_variable_t *var;
         ngx_http_compile_complex_value_t ccv;
 
         if (value[i].data[0] != '$') {
@@ -1205,11 +1211,14 @@ ngx_http_auth_jwt_conf_set_require_variable(ngx_conf_t *cf,
             return "failed to allocate item for require";
         }
 
+        ngx_memzero(var, sizeof(ngx_http_auth_jwt_require_variable_t));
+        var->error = error_code;
+
         ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
 
         ccv.cf = cf;
         ccv.value = &value[i];
-        ccv.complex_value = var;
+        ccv.complex_value = &var->value;
 
         if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
             return "no value variables";
@@ -1439,7 +1448,6 @@ ngx_http_auth_jwt_create_loc_conf(ngx_conf_t *cf)
     conf->revocation.kids = NULL;
     conf->validate.requirement.claims = NULL;
     conf->validate.requirement.headers = NULL;
-    conf->validate.variable.error = NGX_CONF_UNSET;
     conf->validate.variable.values = NULL;
     conf->validate.exp = NGX_CONF_UNSET;
     conf->validate.sig = NGX_CONF_UNSET;
@@ -1538,8 +1546,6 @@ ngx_http_auth_jwt_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
         }
     }
 
-    ngx_conf_merge_value(conf->validate.variable.error,
-                         prev->validate.variable.error, NGX_HTTP_UNAUTHORIZED);
     if (conf->validate.variable.values == NULL
         || conf->validate.variable.values->nelts == 0)
     {
@@ -1548,7 +1554,7 @@ ngx_http_auth_jwt_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
                && prev->validate.variable.values->nelts)
     {
         ngx_uint_t i, len, n;
-        ngx_http_complex_value_t *value, *var;
+        ngx_http_auth_jwt_require_variable_t *value, *var;
 
         len = conf->validate.variable.values->nelts;
         n = prev->validate.variable.values->nelts;
@@ -2034,7 +2040,7 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
     ngx_http_auth_jwt_ctx_t *ctx)
 {
     ngx_uint_t i;
-    ngx_http_complex_value_t *var;
+    ngx_http_auth_jwt_require_variable_t *var;
 
     if (!cf->validate.variable.values) {
         return NGX_OK;
@@ -2045,10 +2051,10 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
     for (i = 0; i < cf->validate.variable.values->nelts; i++) {
         ngx_str_t value = ngx_null_string;
 
-        if (ngx_http_complex_value(r, &var[i], &value) != NGX_OK) {
+        if (ngx_http_complex_value(r, &var[i].value, &value) != NGX_OK) {
             ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                           "auth_jwt: variable specified was not provided: %V",
-                          &(var[i].value));
+                          &(var[i].value.value));
             return NGX_ERROR;
         }
 
@@ -2057,8 +2063,8 @@ ngx_http_auth_jwt_validate_variable(ngx_http_request_t *r,
         {
             ngx_log_error(NGX_LOG_INFO, r->connection->log, 0,
                           "auth_jwt: rejected due to %V variable invalid",
-                          &(var[i].value));
-            ctx->status = cf->validate.variable.error;
+                          &(var[i].value.value));
+            ctx->status = var[i].error;
             return NGX_ERROR;
         }
     }

--- a/t/auth_jwt_require.t
+++ b/t/auth_jwt_require.t
@@ -604,3 +604,122 @@ location / {
   auth_jwt_require error=403;
 }
 --- must_die
+
+=== per-directive error: first default 401 fails, second has error=403
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $jwt_claim_iss $valid_jwt_iss {
+  "fail" 1;
+}
+map $jwt_claim_sub $valid_jwt_sub {
+  "test1.identifier" 1;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+  auth_jwt_require $valid_jwt_iss;
+  auth_jwt_require $valid_jwt_sub error=403;
+}
+--- request
+GET /
+--- error_code: 401
+--- error_log: auth_jwt: rejected due to $valid_jwt_iss variable invalid
+
+=== per-directive error: first error=403 fails, second default 401
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $jwt_claim_iss $valid_jwt_iss {
+  "fail" 1;
+}
+map $jwt_claim_sub $valid_jwt_sub {
+  "test1.identifier" 1;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+  auth_jwt_require $valid_jwt_iss error=403;
+  auth_jwt_require $valid_jwt_sub;
+}
+--- request
+GET /
+--- error_code: 403
+--- error_log: auth_jwt: rejected due to $valid_jwt_iss variable invalid
+
+=== per-directive error: first error=403 passes, second default 401 fails
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $jwt_claim_iss $valid_jwt_iss {
+  "https://test1.issuer.example.com" 1;
+}
+map $jwt_claim_sub $valid_jwt_sub {
+  "fail" 1;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+  auth_jwt_require $valid_jwt_iss error=403;
+  auth_jwt_require $valid_jwt_sub;
+}
+--- request
+GET /
+--- error_code: 401
+--- error_log: auth_jwt: rejected due to $valid_jwt_sub variable invalid
+
+=== per-directive error: first default 401 passes, second error=403 fails
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $jwt_claim_iss $valid_jwt_iss {
+  "https://test1.issuer.example.com" 1;
+}
+map $jwt_claim_sub $valid_jwt_sub {
+  "fail" 1;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+  auth_jwt_require $valid_jwt_iss;
+  auth_jwt_require $valid_jwt_sub error=403;
+}
+--- request
+GET /
+--- error_code: 403
+--- error_log: auth_jwt: rejected due to $valid_jwt_sub variable invalid
+
+=== per-directive error: three directives with distinct error= codes
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $jwt_claim_iss $valid_jwt_iss {
+  "https://test1.issuer.example.com" 1;
+}
+map $jwt_claim_sub $valid_jwt_sub {
+  "test1.identifier" 1;
+}
+map $jwt_claim_email $valid_jwt_email {
+  "fail" 1;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+  auth_jwt_require $valid_jwt_iss;
+  auth_jwt_require $valid_jwt_sub error=403;
+  auth_jwt_require $valid_jwt_email error=404;
+}
+--- request
+GET /
+--- error_code: 404
+--- error_log: auth_jwt: rejected due to $valid_jwt_email variable invalid


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `auth_jwt_require` directive so the `error=` parameter is now scoped independently per directive instance instead of globally, allowing multiple directives to map to different HTTP status codes.

* **Documentation**
  * Updated documentation to clarify per-directive error parameter behavior and provide examples for mapping different directives to different HTTP status codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kjdev/nginx-auth-jwt/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->