### PR TITLE
ci: bump nginx to stable to 1.30.2 and mainline to 1.31.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,8 +158,8 @@ jobs:
         nginx:
           - alpine
           - ubuntu
-          - '1.30.1' # stable
-          - '1.31.0' # mainline
+          - '1.30.2' # stable
+          - '1.31.1' # mainline
     container:
       image: ${{ matrix.nginx == 'alpine' && 'alpine:latest' || null }}
       options: ${{ matrix.nginx == 'alpine' && '--init' || null }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to validate compatibility with newer Nginx versions (1.30.2 and 1.31.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->