### PR TITLE
Fix validate loc conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5b6b1fa](../../commit/5b6b1fa) - 2026-06-15
+
+### Security
+
+- Scope the signature / exp validation relaxation to the request to fix an authentication bypass. `ngx_http_auth_jwt_validate_requirement()` cleared `cf->validate.sig` / `cf->validate.exp` on the worker-shared `loc_conf` when a matching alg or exp requirement was met. Because the `loc_conf` is treated as read-only during request processing, the cleared flags persisted to every later request on that worker until reload. With an alg requirement that allows both `none` and a signing algorithm (e.g. `alg in [RS256, none]`), a single `alg=none` token permanently set `validate.sig` to 0, after which forged RS256 tokens passed signature verification unchecked and bypassed authentication. The fix snapshots `cf->validate.sig` / `exp` into request-scoped ctx fields at the entry of `ngx_http_auth_jwt_validate()` and routes the requirement relaxation and the built-in exp / sig checks through ctx, so the `loc_conf` is never mutated
+
 ## [d2acf47](../../commit/d2acf47) - 2026-06-03
 
 ### Fixed

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -147,6 +147,10 @@ typedef struct {
     ngx_uint_t                    done;
     ngx_uint_t                    subrequest;
     ngx_flag_t                    verified;
+    struct {
+        ngx_flag_t  sig;
+        ngx_flag_t  exp;
+    } validate;
     u_char                       *token;
     size_t                        token_len;
     nxe_jwx_token_t              *jwx_token;
@@ -2313,7 +2317,8 @@ ngx_http_auth_jwt_validate_requirement(ngx_http_request_t *r,
                     }
 
                     // NOTE: do not verify exp if exp requirements are met
-                    cf->validate.exp = 0;
+                    //       (request-scoped: never mutate shared loc_conf)
+                    ctx->validate.exp = 0;
                 }
             }
         }
@@ -2352,7 +2357,8 @@ ngx_http_auth_jwt_validate_requirement(ngx_http_request_t *r,
                     && ngx_strncmp((*algorithm)->data, "none",
                                    (*algorithm)->len) == 0)
                 {
-                    cf->validate.sig = 0;
+                    // NOTE: request-scoped: never mutate shared loc_conf
+                    ctx->validate.sig = 0;
                 }
                 // NOTE: do not verify algorithm if alg requirements are met
                 *algorithm = NULL;
@@ -2376,6 +2382,14 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
                       "auth_jwt: rejected due to missing required arguments");
         return NGX_ERROR;
     }
+
+    /* Snapshot the configured validation flags into request scope.  The
+     * requirement checks below may relax sig/exp verification when a
+     * matching requirement is met, but those relaxations must stay local
+     * to this request: writing back into the shared loc_conf would carry
+     * over to every later request on this worker. */
+    ctx->validate.sig = cf->validate.sig;
+    ctx->validate.exp = cf->validate.exp;
 
     /* nxe_jwx_token_alg / _kid return ngx_str_t whose data is not
      * documented as NUL-terminated; keep the values as ngx_str_t * and
@@ -2450,7 +2464,7 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     }
 
     /* validate exp claim */
-    if (cf->validate.exp) {
+    if (ctx->validate.exp) {
         time_t exp, now;
 
         exp = ngx_http_auth_jwt_get_grant_time(r, ctx->jwt, "exp", NULL, NULL);
@@ -2492,7 +2506,7 @@ ngx_http_auth_jwt_validate(ngx_http_request_t *r,
     }
 
     /* validate signature */
-    if (!cf->validate.sig) {
+    if (!ctx->validate.sig) {
         ctx->verified = 1;
         return ngx_http_auth_jwt_validate_variable(r, cf, ctx);
     }

--- a/t/auth_jwt_require_loc_conf_persist.t
+++ b/t/auth_jwt_require_loc_conf_persist.t
@@ -1,0 +1,70 @@
+use Test::Nginx::Socket 'no_plan';
+
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== test: alg none requirement does not permanently disable signature validation
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $http_x_token $jwt {
+  default  $test1_invalid_sig_jwt;
+  "none"   $test0_jwt;
+  "forged" $test1_invalid_sig_jwt;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_require_header alg in json=["HS256","none"];
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request eval
+[
+  "GET /",
+  "GET /"
+]
+--- more_headers eval
+[
+  "X-Token: none",
+  "X-Token: forged"
+]
+--- error_code eval
+[
+  200,
+  401
+]
+
+=== test: builtin exp validation is applied on every request
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+map $http_x_token $jwt {
+  "future"  $test1_jwt;
+  "expired" $test1_invalid_exp_jwt;
+}
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- request eval
+[
+  "GET /",
+  "GET /"
+]
+--- more_headers eval
+[
+  "X-Token: future",
+  "X-Token: expired"
+]
+--- error_code eval
+[
+  200,
+  401
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Fixed a JWT authentication bypass caused by validation relaxation state persisting across requests. Signature and expiration enforcement are now correctly tied to each request.

* **Tests**
  * Added a new nginx Test::Nginx script covering location-config persistence and ensuring both signature relaxation handling and built-in expiration checks behave correctly across multiple requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->