### PR TITLE
ci: bump nginx to stable to 1.30.3 and mainline to 1.31.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,8 +158,8 @@ jobs:
         nginx:
           - alpine
           - ubuntu
-          - '1.30.2' # stable
-          - '1.31.1' # mainline
+          - '1.30.3' # stable
+          - '1.31.2' # mainline
     container:
       image: ${{ matrix.nginx == 'alpine' && 'alpine:latest' || null }}
       options: ${{ matrix.nginx == 'alpine' && '--init' || null }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configurations to verify compatibility with latest stable and mainline software versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->