### PR TITLE
Fix preaccess phase ngx ok skips limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Stop `auth_jwt_phase preaccess;` from causing the module's success terminal to skip the rest of the PREACCESS phase. nginx's generic phase checker (`ngx_http_core_generic_phase()`, used for PREACCESS) advances `r->phase_handler` to the next *phase* on `NGX_OK` but only to the next *handler in the same phase* on `NGX_DECLINED`. The module's success path (`ngx_http_auth_jwt_http_ok()`) always returned `NGX_OK` regardless of `phase`, so in preaccess mode a successful request skipped every other PREACCESS handler registered after it — including `limit_req` / `limit_conn` and third-party modules such as [`nginx-ratelimit`](https://github.com/kjdev/nginx-ratelimit) that key on `$jwt_claim_sub` and similar variables populated by this module. Since those handlers never ran, per-identity rate limiting on the resolved JWT claims was silently a no-op whenever `auth_jwt_phase preaccess;` was used. `ngx_http_auth_jwt_http_ok()` now returns `NGX_DECLINED` when `phase == NGX_HTTP_PREACCESS_PHASE` (and `NGX_OK` otherwise), matching the convention used by variable-populating PREACCESS handlers like `realip`. Authentication enforcement is unaffected: a failed authentication still finalizes the request with 401/500 through the existing error path
+
 ## [0.14.1] - 2026-06-15
 
 ### Security

--- a/docs/DIRECTIVES.md
+++ b/docs/DIRECTIVES.md
@@ -174,7 +174,21 @@ Context: http, server, location
 
 Specifies the nginx processing phase in which JWT authentication runs.
 
+When `preaccess` is specified, on successful authentication this module
+continues phase processing instead of skipping the remaining handlers of the
+same PREACCESS phase, after resolving `$jwt_claim_*` and other variables.
+This lets other modules registered in the same PREACCESS phase, such as
+`limit_req`, `limit_conn`, or
+[`nginx-ratelimit`](https://github.com/kjdev/nginx-ratelimit), key on those
+claim variables (authentication is still enforced, since a failed
+authentication finalizes the request with 401/500 as before).
+
 > Note: The ACCESS phase is not executed when called from a subrequest. When called from a subrequest, `auth_jwt_key_request` cannot be processed (nested in-memory subrequest).
+>
+> Note: nginx core's `auth_delay` (brute-force delay for 401 responses) is
+> only implemented in the ACCESS phase checker and does not exist in the
+> PREACCESS phase. Consequently, when `auth_jwt_phase preaccess;` is set,
+> `auth_delay` does not apply to the 401 responses returned by this module.
 
 ### auth_jwt_revocation_list_sub
 

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -1899,6 +1899,9 @@ ngx_http_auth_jwt_response(ngx_http_request_t *r,
 }
 
 #define ngx_http_auth_jwt_http_ok() ngx_http_auth_jwt_response(r, cf, ctx, 0, \
+                                                               phase == \
+                                                               NGX_HTTP_PREACCESS_PHASE \
+                                                               ? NGX_DECLINED : \
                                                                NGX_OK)
 #define ngx_http_auth_jwt_http_error_without_token() ngx_http_auth_jwt_response( \
             r, cf, ctx, 0, \

--- a/t/auth_jwt_phase_limit_req.t
+++ b/t/auth_jwt_phase_limit_req.t
@@ -1,0 +1,26 @@
+use Test::Nginx::Socket 'no_plan';
+
+no_root_location();
+no_shuffle();
+
+run_tests();
+
+__DATA__
+
+=== preaccess phase populates $jwt_claim_sub before limit_req in the same PREACCESS phase
+--- http_config
+include $TEST_NGINX_CONF_DIR/authorized_server.conf;
+limit_req_zone $jwt_claim_sub zone=auth_jwt_phase_sub:1m rate=1r/s;
+--- config
+include $TEST_NGINX_CONF_DIR/jwt.conf;
+location / {
+  auth_jwt "" token=$test1_jwt;
+  auth_jwt_key_file $TEST_NGINX_DATA_DIR/jwks.json;
+  auth_jwt_phase preaccess;
+  limit_req zone=auth_jwt_phase_sub;
+  include $TEST_NGINX_CONF_DIR/authorized_proxy.conf;
+}
+--- pipelined_requests eval
+["GET /", "GET /"]
+--- error_code eval
+[200, 503]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue in the PREACCESS phase where successful JWT authentication could skip subsequent handlers.
  - Ensured JWT claims are still available for downstream controls, including request rate limiting.
  - Kept authentication enforcement and failure response behavior unchanged.
- **Documentation**
  - Updated `auth_jwt_phase` documentation to reflect correct PREACCESS continuation, subrequest limitations, and `auth_delay` behavior.
- **Tests**
  - Added a new PREACCESS-focused test verifying `$jwt_claim_*` is populated before rate limiting runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->